### PR TITLE
fix `as.incfreq()` warnings, clarify documentation and add tests

### DIFF
--- a/R/invChat.R
+++ b/R/invChat.R
@@ -356,9 +356,9 @@ estimateD <- function(x, datatype="abundance", base="size", level=NULL, conf=0.9
 ###############################################
 #' Transform incidence raw data to incidence frequencies (iNEXT input format) 
 #' 
-#' \code{as.incfreq}: transform incidence raw data (a species by sites presence-absence matrix) to incidence frequencies data (iNEXT input format, a row-sum frequencies vector contains total number of sampling units).
-#' @param x a \code{data.frame} or \code{matirx} of species by sites presence-absence matrix.
-#' @return a \code{vector} of species incidence frequencies, the first entry of the input data must be total number of sampling units.
+#' \code{as.incfreq}: transform incidence raw data (a species by sites presence-absence matrix) to incidence frequencies data (iNEXT input format, a row-sum frequencies vector that contains the total number of sampling units).
+#' @param x a \code{data.frame} or \code{matrix} of species by sites presence-absence matrix.
+#' @return a \code{vector} of species incidence frequencies, the first element being the total number of sampling units.
 #' @examples
 #' data(ciliates)
 #' lapply(ciliates, as.incfreq)
@@ -368,9 +368,9 @@ estimateD <- function(x, datatype="abundance", base="size", level=NULL, conf=0.9
 as.incfreq <- function(x){
   class_x <- class(x)[1]
   if(class_x == "data.frame" | class_x == "matrix"){
-    a <- sort(as.numeric(unique(c(unlist(x)))))
-    if(!identical(a, c(0,1))){
-      warning("Invalid data type, the element of species by sites presence-absence matrix should be 0 or 1. Set nonzero elements as 1.")
+    a <- na.omit(as.numeric(unique(c(unlist(x)))))
+    if(!all(a %in% c(0,1))){
+      warning("Invalid data type: the elements of the species by sites presence-absence matrix should be 0 or 1. Nonzero elements were set to 1.")
       x <- (x > 0)
     }
     nT <- ncol(x)
@@ -379,10 +379,10 @@ as.incfreq <- function(x){
     # names(y) <- c("nT", rownames(x))
     y
   }else if(class_x=="numeric" | class_x=="integer" | class_x=="double"){
-    warnings("Ambiguous data type, the input object is a vector. Set total number of sampling units as 1.")
+    warnings("Ambiguous data type, the input object is a vector. Total number of sampling units set to 1.")
     c(1, x) 
   }else{
-    stop("Invalid data type, it should be a data.frame or matrix.")
+    stop("Invalid data type, should be a data.frame or matrix.")
   }
 }
 

--- a/R/invChat.R
+++ b/R/invChat.R
@@ -379,8 +379,8 @@ as.incfreq <- function(x){
     # names(y) <- c("nT", rownames(x))
     y
   }else if(class_x=="numeric" | class_x=="integer" | class_x=="double"){
-    warnings("Ambiguous data type, the input object is a vector. Total number of sampling units set to 1.")
-    c(1, x) 
+    warning("Ambiguous data type, the input object is a vector. Total number of sampling units set to 1.")
+    c(1, x)
   }else{
     stop("Invalid data type, should be a data.frame or matrix.")
   }

--- a/tests/testthat/test-iNEXT.R
+++ b/tests/testthat/test-iNEXT.R
@@ -62,6 +62,23 @@ test_that("iNEXT for species by sampling-units incidence matrix", {
   # expect_output(str(out), "List of 3")
   # expect_equal(names(out$DataInfo)[2], "T")
   # expect_equal(nrow(out$DataInfo), 1)
+  
+})
+
+test_that("as.incfreq handles values appropriately", {
+  # example dataframes
+  test_df0 <- data.frame(col1 = rep.int(0, 4)) # only 0s
+  test_df1 <- data.frame(col1 = rep.int(1, 4)) # only 1s
+  test_df01 <- data.frame(col1 = rep.int(0:1, 2)) # both
+  test_df12 <- data.frame(col1 = rep.int(1:2, 2)) # with other than 0 and 1
+  expect_equal(length(as.incfreq(test_df0)), nrow(test_df0)+1)
+  expect_equal(length(as.incfreq(test_df1)), nrow(test_df1)+1)
+  expect_equal(length(as.incfreq(test_df01)), nrow(test_df01)+1)
+  expect_equal(length(as.incfreq(test_df12)), nrow(test_df12)+1)
+  expect_warning(as.incfreq(test_df12))
+  # vector instead of dataframe or matrix
+  expect_equal(length(as.incfreq(test_df1$col1)), length(test_df1$col1)+1)
+  expect_warning(as.incfreq(test_df1$col1))
 })
 
 


### PR DESCRIPTION
`as.incfreq()` would throw a warning when the presence-absence data was only 0s or only 1s.

For example, try the following in the current release:

```r
test_df0 <- data.frame(col1 = rep.int(0, 10))
library(iNEXT)
as.incfreq(test_df0)
```

This PR fixes the following:

* Make it so warning is not shown when only either 1 or 0 is present
* Clarify warnings and documentation
* Use `warning()` instead of `warnings()` for the vector warning (assumed to be a typo)
* Add tests for `as.infreq()`

I am not particularly familiar with the package, so wanted to also ask:

* Is the current behaviour for NAs correct? (As in, keeps the NA, and returns NAs as row sums)
* What should happen if there are negative values in the matrix or dataframe? Currently, they are not convert to 1s in line 374.