### PR TITLE
Modify estimateD's error from 'duplicated'.

### DIFF
--- a/R/invChat.R
+++ b/R/invChat.R
@@ -332,8 +332,6 @@ estimateD <- function(x, datatype="abundance", base="size", level=NULL, conf=0.9
     tmp <- invChat(x, datatype, C=level, conf=conf)
   }
   
-  tmp <- tmp[!duplicated(tmp),]
-  
   nam <- names(x)
   if(is.null(nam)){
     tmp


### PR DESCRIPTION
In the function 'estimateD', if there are the same outputs  from different site (include C.I.),  then 'duplicated' will delete one row and then the dimension will mislead.