### PR TITLE
New argument to `estimateD` to warn about duplicates and optionally remove without error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     reshape2
 BugReports: https://github.com/JohnsonHsieh/iNEXT/issues
 LazyLoad: yes
-RoxygenNote: 6.1.1
+RoxygenNote: 7.2.0
 Suggests: testthat,
     knitr,
     rmarkdown,

--- a/R/invChat.R
+++ b/R/invChat.R
@@ -287,6 +287,7 @@ invSize <- function(x, datatype="abundance", size=NULL, conf=NULL){
 #' If \code{base="size"} and \code{level=NULL}, then this function computes the diversity estimates for the minimum sample size among all sites. 
 #' If \code{base="coverage"} and \code{level=NULL}, then this function computes the diversity estimates for the minimum sample coverage among all sites. 
 #' @param conf a positive number < 1 specifying the level of confidence interval, default is 0.95. Remove C.I. by setting conf=NULL.
+#' @param removeDups Logical, remove (some) duplicates? 
 #' @return a \code{data.frame} of species diversity table including the sample size, sample coverage,
 #' method (rarefaction or extrapolation), and diversity estimates with q = 0, 1, and 2 for the user-specified sample size or sample coverage.
 #' @examples
@@ -298,7 +299,7 @@ invSize <- function(x, datatype="abundance", size=NULL, conf=NULL){
 #' data(ant)
 #' estimateD(ant, "incidence_freq", base="coverage", level=0.985, conf=NULL)
 #' @export
-estimateD <- function(x, datatype="abundance", base="size", level=NULL, conf=0.95){
+estimateD <- function(x, datatype="abundance", base="size", level=NULL, conf=0.95, removeDups = FALSE){
   TYPE <- c("abundance", "incidence", "incidence_freq", "incidence_raw")
   #TYPE <- c("abundance", "incidence")
   if(is.na(pmatch(datatype, TYPE)))
@@ -331,19 +332,25 @@ estimateD <- function(x, datatype="abundance", base="size", level=NULL, conf=0.9
   }else if(base=="coverage"){
     tmp <- invChat(x, datatype, C=level, conf=conf)
   }
+  tmp2 <- tmp[!duplicated(tmp),]
+  if(!all.equal(tmp, tmp2)){message("diversity output contains duplicate rows that were removed)")}
+  if(removeDups){
+    nam <- names(x[[!duplicated(tmp)]])}
+  else{tmp2 <- tmp
+  nam <-names(x)}
   
-  tmp <- tmp[!duplicated(tmp),]
-  
-  nam <- names(x)
+ 
+    
+
   if(is.null(nam)){
-    tmp
-  }else if(ncol(tmp)==6){
-    tmp <- cbind(site=nam, tmp)
+    tmp2
+  }else if(ncol(tmp2)==6){
+    tmp2 <- cbind(site=nam, tmp2)
   }else{
-    tmp <- cbind(site=rep(nam, each=3), tmp)
+    tmp2 <- cbind(site=rep(nam, each=3), tmp2)
   }
-  rownames(tmp) <- NULL
-  tmp
+  rownames(tmp2) <- NULL
+  tmp2
 }
 
 

--- a/man/ChaoShannon.Rd
+++ b/man/ChaoShannon.Rd
@@ -5,11 +5,9 @@
 \alias{ChaoEntropy}
 \title{Estimation of Shannon entropy/diversity}
 \usage{
-ChaoShannon(x, datatype = "abundance", transform = FALSE,
-  conf = 0.95, B = 200)
+ChaoShannon(x, datatype = "abundance", transform = FALSE, conf = 0.95, B = 200)
 
-ChaoEntropy(x, datatype = "abundance", transform = FALSE,
-  conf = 0.95, B = 200)
+ChaoEntropy(x, datatype = "abundance", transform = FALSE, conf = 0.95, B = 200)
 }
 \arguments{
 \item{x}{a vector of species abundances or incidence frequencies. If \code{datatype = "incidence"}, 

--- a/man/ChaoSimpson.Rd
+++ b/man/ChaoSimpson.Rd
@@ -5,11 +5,9 @@
 \alias{EstSimpson}
 \title{Estimation of Gini-Simpson index or Simpson diversity}
 \usage{
-ChaoSimpson(x, datatype = "abundance", transform = FALSE,
-  conf = 0.95, B = 200)
+ChaoSimpson(x, datatype = "abundance", transform = FALSE, conf = 0.95, B = 200)
 
-EstSimpson(x, datatype = "abundance", transform = FALSE, conf = 0.95,
-  B = 200)
+EstSimpson(x, datatype = "abundance", transform = FALSE, conf = 0.95, B = 200)
 }
 \arguments{
 \item{x}{a vector of species abundances or incidence frequencies. If \code{datatype = "incidence"}, 

--- a/man/estimateD.Rd
+++ b/man/estimateD.Rd
@@ -4,8 +4,14 @@
 \alias{estimateD}
 \title{Compute species diversity with a particular of sample size/coverage}
 \usage{
-estimateD(x, datatype = "abundance", base = "size", level = NULL,
-  conf = 0.95)
+estimateD(
+  x,
+  datatype = "abundance",
+  base = "size",
+  level = NULL,
+  conf = 0.95,
+  removeDups = FALSE
+)
 }
 \arguments{
 \item{x}{a \code{data.frame} or \code{list} of species abundances or incidence frequencies.\cr 
@@ -22,6 +28,8 @@ If \code{base="size"} and \code{level=NULL}, then this function computes the div
 If \code{base="coverage"} and \code{level=NULL}, then this function computes the diversity estimates for the minimum sample coverage among all sites.}
 
 \item{conf}{a positive number < 1 specifying the level of confidence interval, default is 0.95. Remove C.I. by setting conf=NULL.}
+
+\item{removeDups}{Logical, remove (some) duplicates?}
 }
 \value{
 a \code{data.frame} of species diversity table including the sample size, sample coverage,

--- a/man/ggiNEXT.Rd
+++ b/man/ggiNEXT.Rd
@@ -6,11 +6,23 @@
 \alias{ggiNEXT.default}
 \title{ggplot2 extension for an iNEXT object}
 \usage{
-ggiNEXT(x, type = 1, se = TRUE, facet.var = "none",
-  color.var = "site", grey = FALSE)
+ggiNEXT(
+  x,
+  type = 1,
+  se = TRUE,
+  facet.var = "none",
+  color.var = "site",
+  grey = FALSE
+)
 
-\method{ggiNEXT}{iNEXT}(x, type = 1, se = TRUE, facet.var = "none",
-  color.var = "site", grey = FALSE)
+\method{ggiNEXT}{iNEXT}(
+  x,
+  type = 1,
+  se = TRUE,
+  facet.var = "none",
+  color.var = "site",
+  grey = FALSE
+)
 
 \method{ggiNEXT}{default}(x, ...)
 }

--- a/man/iNEXT.Rd
+++ b/man/iNEXT.Rd
@@ -4,9 +4,17 @@
 \alias{iNEXT}
 \title{iNterpolation and EXTrapolation of Hill number}
 \usage{
-iNEXT(x, q = 0, datatype = "abundance", size = NULL,
-  endpoint = NULL, knots = 40, se = TRUE, conf = 0.95,
-  nboot = 50)
+iNEXT(
+  x,
+  q = 0,
+  datatype = "abundance",
+  size = NULL,
+  endpoint = NULL,
+  knots = 40,
+  se = TRUE,
+  conf = 0.95,
+  nboot = 50
+)
 }
 \arguments{
 \item{x}{a matrix, data.frame (species by sites), or list of species abundances or incidence frequencies. If \code{datatype = "incidence"}, then the first entry of the input data must be total number of sampling units in each column or list.}

--- a/man/plot.iNEXT.Rd
+++ b/man/plot.iNEXT.Rd
@@ -4,8 +4,15 @@
 \alias{plot.iNEXT}
 \title{Plotting iNEXT object}
 \usage{
-\method{plot}{iNEXT}(x, type = 1, se = TRUE, show.legend = TRUE,
-  show.main = TRUE, col = NULL, ...)
+\method{plot}{iNEXT}(
+  x,
+  type = 1,
+  se = TRUE,
+  show.legend = TRUE,
+  show.main = TRUE,
+  col = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{an \code{iNEXT} object computed by \code{\link{iNEXT}}.}


### PR DESCRIPTION
This (like another PR from [KaiHsiangHu](https://github.com/KaiHsiangHu)) was an attempt to resolve #67. I added a warning about duplicates and an `removeDups` argument to estimateD that I think, when TRUE, removes duplicates without throwing an error due to name mismatches. The documentation didn't exactly update for me with `devtools::document()`, and this PR wasn't passing R CMD check on my machine, but I think that will be very quick for the maintainers.