### PR TITLE
Reassign class of x after it is converted with as.incfreq

### DIFF
--- a/R/iNEXT.r
+++ b/R/iNEXT.r
@@ -572,6 +572,7 @@ iNEXT <- function(x, q=0, datatype="abundance", size=NULL, endpoint=NULL, knots=
       x <- lapply(x, as.incfreq)
     }else{
       x <- as.incfreq(x)
+      class_x <- class(x)
     }
     datatype <- "incidence"
   }
@@ -617,9 +618,9 @@ iNEXT <- function(x, q=0, datatype="abundance", size=NULL, endpoint=NULL, knots=
   }
   
   if(!inherits(q, "numeric"))
-    stop("invlid class of order q, q should be a postive value/vector of numeric object")
+    stop("invalid class of order q, q should be a positive value/vector of numeric object")
   if(min(q) < 0){
-    warning("ambigous of order q, we only compute postive q")
+    warning("ambiguous of order q, we only compute positive q")
     q <- q[q >= 0]
   }
   

--- a/tests/testthat/test-iNEXT.R
+++ b/tests/testthat/test-iNEXT.R
@@ -55,13 +55,13 @@ test_that("iNEXT for species by sampling-units incidence matrix", {
   expect_equal(nrow(out$DataInfo), length(ciliates))
   
   # Test input by a data.frame
-  # x <- ciliates$EtoshaPan
-  # # expect_equal(class(x), "matrix")
-  # out <- iNEXT(x, q=0, datatype="incidence_raw")
-  # expect_is(out, "iNEXT")
-  # expect_output(str(out), "List of 3")
-  # expect_equal(names(out$DataInfo)[2], "T")
-  # expect_equal(nrow(out$DataInfo), 1)
+  x <- ciliates$EtoshaPan
+  expect_equal(class(x)[1], "matrix")
+  out <- iNEXT(x, q=0, datatype="incidence_raw")
+  expect_is(out, "iNEXT")
+  expect_output(str(out), "List of 3")
+  expect_equal(names(out$DataInfo)[2], "T")
+  expect_equal(nrow(out$DataInfo), 1)
 })
 
 


### PR DESCRIPTION
This fixes the error, documented in issue #78 , that occurs when passing a data frame or matrix to `iNEXT()` with `datatype = 'incidence_raw'`. The input is converted to frequency using `as.incfreq()`. The resulting object has class `numeric` but the variable `class_x` is still `data.frame` or `matrix`. Therefore, the control flow executes the section of code under `if(class_x=="matrix" | class_x=="data.frame")`. This results in an error because `ncol(x)` is `NULL`. 

To fix this error, I just added `class_x <- class(x)` after `x` is converted to incfreq. I also uncommented the test to make sure `iNEXT()` works properly if it gets a raw incidence data.frame as input. The tests all pass.

Thank you for considering this pull request!